### PR TITLE
Fix Gemini Authentication: Explicitly pass GOOGLE_API_KEY to constructor

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, List
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.callbacks.base import BaseCallbackHandler
-from config import OLLAMA_BASE_URL, OPENROUTER_BASE_URL, OPENROUTER_API_KEY
+from config import OLLAMA_BASE_URL, OPENROUTER_BASE_URL, OPENROUTER_API_KEY, GOOGLE_API_KEY
 
 
 class BufferedStreamingHandler(BaseCallbackHandler):
@@ -71,15 +71,15 @@ _llm_config_map = {
     },
     'gemini-2.5-flash': {
         'class': ChatGoogleGenerativeAI,
-        'constructor_params': {'model': 'gemini-2.5-flash'}
+        'constructor_params': {'model': 'gemini-2.5-flash', 'google_api_key': GOOGLE_API_KEY }
     },
     'gemini-2.5-flash-lite': {
         'class': ChatGoogleGenerativeAI,
-        'constructor_params': {'model': 'gemini-2.5-flash-lite'}
+        'constructor_params': {'model': 'gemini-2.5-flash-lite', 'google_api_key': GOOGLE_API_KEY}
     },
     'gemini-2.5-pro': {
         'class': ChatGoogleGenerativeAI,
-        'constructor_params': {'model': 'gemini-2.5-pro'}
+        'constructor_params': {'model': 'gemini-2.5-pro', 'google_api_key': GOOGLE_API_KEY}
     },
     'llama3.2': {
         'class': ChatOllama,


### PR DESCRIPTION
This PR resolves Issue #52 where users were encountering a `google.auth.exceptions.DefaultCredentialsError` when using Gemini models.

**The Issue:**
Previously, the application relied on `langchain-google-genai` to automatically detect the `GOOGLE_API_KEY` from the environment. However, in certain environments, the library fails to pick up the variable and falls back to Google's "Application Default Credentials" (ADC) flow, which causes a crash if the user hasn't set up the Google Cloud CLI.

**The Fix:**
I have updated `llm_utils.py` to:
1.  Import `GOOGLE_API_KEY` from `config.py`.
2.  Explicitly pass the `google_api_key` parameter to the `ChatGoogleGenerativeAI` constructor for all Gemini model configurations (`gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`).

This ensures the application always uses the key provided in the `.env` file, bypassing the faulty auto-discovery/ADC fallback mechanism.