### PR TITLE
Fix: remove DarkHunt search endpoint (fixes #69)

### DIFF
--- a/search.py
+++ b/search.py
@@ -21,7 +21,6 @@ USER_AGENTS = [
 SEARCH_ENGINE_ENDPOINTS = [
     "http://juhanurmihxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion/search/?q={query}", # Ahmia
     "http://3bbad7fauom4d6sgppalyqddsqbf5u5p56b5k5uk2zxsy3d6ey2jobad.onion/search?q={query}", # OnionLand
-    "http://darkhuntyla64h75a3re5e2l3367lqn7ltmdzpgmr6b4nbz3q2iaxrid.onion/search?q={query}", # DarkHunt
     "http://iy3544gmoeclh5de6gez2256v6pjh4omhpqdh2wpeeppjtvqmjhkfwad.onion/torgle/?query={query}", # Torgle
     "http://amnesia7u5odx5xbwtpnqk3edybgud5bmiagu75bnqx2crntw5kry7ad.onion/search?query={query}", # Amnesia
     "http://kaizerwfvp5gxu6cppibp7jhcqptavq3iqef66wbxenh6a2fklibdvid.onion/search?q={query}", # Kaizer


### PR DESCRIPTION
## Description
Removes the DarkHunt search engine endpoint from the `SEARCH_ENGINE_ENDPOINTS` list as the service is no longer available.

## Changes
- Removed DarkHunt endpoint line from `search.py`

## Related Issue
Closes #69 

## Testing
- Verified no other references to DarkHunt remain in the codebase
- Robin will now query 16 dark web search engines instead of 17

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes have been tested locally
- [x] All references to the deprecated service have been removed