### PR TITLE
Harden scraper URL policy and redirect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 > [!TIP]
 > You can provide your LLM of choice API key by either creating .env file (refer to sample env file in the repo) or by setting env variables in PATH.
 >
+> Use plain values in `.env` (no extra spaces). Quotes are optional, but accidental trailing characters can break auth.
+>
 > For Ollama, provide `http://host.docker.internal:11434` as `OLLAMA_BASE_URL` in your env if running using docker method or `http://127.0.0.1:11434` for other methods. You might need to serve Ollama on 0.0.0.0 depending on your OS. You can do by running `OLLAMA_HOST=0.0.0.0 ollama serve &` in your terminal.
 > To explicitly allow scraping non-onion links (disabled by default), set `ALLOW_CLEARWEB_FALLBACK=true`.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 > You can provide your LLM of choice API key by either creating .env file (refer to sample env file in the repo) or by setting env variables in PATH.
 >
 > For Ollama, provide `http://host.docker.internal:11434` as `OLLAMA_BASE_URL` in your env if running using docker method or `http://127.0.0.1:11434` for other methods. You might need to serve Ollama on 0.0.0.0 depending on your OS. You can do by running `OLLAMA_HOST=0.0.0.0 ollama serve &` in your terminal.
+> To explicitly allow scraping non-onion links (disabled by default), set `ALLOW_CLEARWEB_FALLBACK=true`.
 
 ### Docker [Recommended]
 

--- a/config.py
+++ b/config.py
@@ -3,6 +3,13 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def _get_bool_env(name, default=False):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
 # Configuration variables loaded from the .env file
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
@@ -11,3 +18,4 @@ OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 LLAMA_CPP_BASE_URL= os.getenv("LLAMA_CPP_BASE_URL")
+ALLOW_CLEARWEB_FALLBACK = _get_bool_env("ALLOW_CLEARWEB_FALLBACK", default=False)

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ def _clean_env(name, default=None):
     ):
         value = value[1:-1].strip()
     return value
-	
+
 # Configuration variables loaded from the .env file
 OPENAI_API_KEY = _clean_env("OPENAI_API_KEY")
 GOOGLE_API_KEY = _clean_env("GOOGLE_API_KEY")

--- a/config.py
+++ b/config.py
@@ -3,15 +3,28 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def _clean_env(name, default=None):
+    value = os.getenv(name, default)
+    if value is None:
+        return None
+    value = str(value).strip()
+    # Support accidentally quoted values copied into .env
+    if len(value) >= 2 and (
+        (value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")
+    ):
+        value = value[1:-1].strip()
+    return value
+	
 # Configuration variables loaded from the .env file
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
-ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
-OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
-OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-LLAMA_CPP_BASE_URL = os.getenv("LLAMA_CPP_BASE_URL")
-ALLOW_CLEARWEB_FALLBACK = str(os.getenv("ALLOW_CLEARWEB_FALLBACK", "false")).strip().lower() in {
+OPENAI_API_KEY = _clean_env("OPENAI_API_KEY")
+GOOGLE_API_KEY = _clean_env("GOOGLE_API_KEY")
+ANTHROPIC_API_KEY = _clean_env("ANTHROPIC_API_KEY")
+OLLAMA_BASE_URL = _clean_env("OLLAMA_BASE_URL")
+OPENROUTER_BASE_URL = _clean_env("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+OPENROUTER_API_KEY = _clean_env("OPENROUTER_API_KEY")
+LLAMA_CPP_BASE_URL = _clean_env("LLAMA_CPP_BASE_URL")
+ALLOW_CLEARWEB_FALLBACK = str(_clean_env("ALLOW_CLEARWEB_FALLBACK", "false")).strip().lower() in {
     "1",
     "true",
     "yes",

--- a/config.py
+++ b/config.py
@@ -3,13 +3,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-
-def _get_bool_env(name, default=False):
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
-
 # Configuration variables loaded from the .env file
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
@@ -18,4 +11,9 @@ OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 LLAMA_CPP_BASE_URL= os.getenv("LLAMA_CPP_BASE_URL")
-ALLOW_CLEARWEB_FALLBACK = _get_bool_env("ALLOW_CLEARWEB_FALLBACK", default=False)
+ALLOW_CLEARWEB_FALLBACK = str(os.getenv("ALLOW_CLEARWEB_FALLBACK", "false")).strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-LLAMA_CPP_BASE_URL= os.getenv("LLAMA_CPP_BASE_URL")
+LLAMA_CPP_BASE_URL = os.getenv("LLAMA_CPP_BASE_URL")
 ALLOW_CLEARWEB_FALLBACK = str(os.getenv("ALLOW_CLEARWEB_FALLBACK", "false")).strip().lower() in {
     "1",
     "true",

--- a/scrape.py
+++ b/scrape.py
@@ -79,7 +79,8 @@ def _is_safe_url(url, allow_clearweb=False, resolve_hostname=True):
 
     if not resolve_hostname:
         # Avoid local DNS lookups when traffic is already routed through Tor.
-        return True
+        # In this mode, treat non-onion hostnames as unsafe.
+        return False
 
     try:
         resolved = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
@@ -112,7 +113,9 @@ def _safe_fetch_with_redirect_policy(
         if response.status_code in {301, 302, 303, 307, 308} and response.headers.get("Location"):
             next_url = urljoin(current, response.headers["Location"])
             if not _is_safe_url(next_url, allow_clearweb=allow_clearweb, resolve_hostname=resolve_hostname):
+                response.close()
                 raise ValueError(f"Blocked redirect by security policy: {next_url}")
+            response.close()
             current = next_url
             continue
         return response
@@ -174,6 +177,7 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
         "User-Agent": random.choice(USER_AGENTS)
     }
     
+    response = None
     try:
         if use_tor:
             session = get_tor_session()
@@ -212,6 +216,9 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
         # Return title only on failure, so we don't lose the reference
         logger.debug("Failed scraping URL '%s': %s", url, e)
         scraped_text = url_data['title']
+    finally:
+        if response is not None:
+            response.close()
     
     return url, scraped_text
 

--- a/scrape.py
+++ b/scrape.py
@@ -167,7 +167,8 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
     Returns a tuple (url, scraped_text).
     """
     url = url_data['link']
-    use_tor = ".onion" in url
+    hostname = (urlparse(url).hostname or "").lower()
+    use_tor = hostname.endswith(".onion")
     
     headers = {
         "User-Agent": random.choice(USER_AGENTS)

--- a/scrape.py
+++ b/scrape.py
@@ -1,10 +1,15 @@
 import random
 import requests
-import threading
+import ipaddress
+import socket
+import logging
+from urllib.parse import urlparse, urljoin
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from bs4 import BeautifulSoup
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from config import ALLOW_CLEARWEB_FALLBACK
 
 import warnings
 warnings.filterwarnings("ignore")
@@ -21,6 +26,86 @@ USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.3179.54",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.3179.54"
 ]
+
+_BLOCKED_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "ip6-localhost",
+    "ip6-loopback",
+}
+
+logger = logging.getLogger(__name__)
+
+
+def _is_private_or_local_ip(value):
+    try:
+        ip = ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _is_safe_url(url, allow_clearweb=False):
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    if not hostname:
+        return False
+
+    if hostname.endswith(".onion"):
+        return True
+
+    if not allow_clearweb:
+        return False
+
+    if hostname in _BLOCKED_HOSTNAMES:
+        return False
+
+    ip_check = _is_private_or_local_ip(hostname)
+    if ip_check is True:
+        return False
+    if ip_check is False:
+        return True
+
+    try:
+        resolved = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except Exception:
+        return False
+
+    for item in resolved:
+        resolved_ip = item[4][0]
+        if _is_private_or_local_ip(resolved_ip):
+            return False
+
+    return True
+
+
+def _safe_fetch_with_redirect_policy(session, url, headers, timeout, allow_clearweb=False, max_redirects=3):
+    if not _is_safe_url(url, allow_clearweb=allow_clearweb):
+        raise ValueError(f"Blocked URL by security policy: {url}")
+
+    current = url
+    for _ in range(max_redirects + 1):
+        response = session.get(current, headers=headers, timeout=timeout, allow_redirects=False)
+        if response.status_code in {301, 302, 303, 307, 308} and response.headers.get("Location"):
+            next_url = urljoin(current, response.headers["Location"])
+            if not _is_safe_url(next_url, allow_clearweb=allow_clearweb):
+                raise ValueError(f"Blocked redirect by security policy: {next_url}")
+            current = next_url
+            continue
+        return response
+
+    raise ValueError("Blocked URL due to excessive redirects")
 
 def get_tor_session():
     """
@@ -57,13 +142,16 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
     }
     
     try:
-        if use_tor:
-            session = get_tor_session()
-            # Increased timeout for Tor latency
-            response = session.get(url, headers=headers, timeout=45)
-        else:
-            # Fallback for clearweb if needed, though tool focuses on dark web
-            response = requests.get(url, headers=headers, timeout=30)
+        session = get_tor_session()
+        timeout = 45 if use_tor else 30
+        response = _safe_fetch_with_redirect_policy(
+            session,
+            url,
+            headers=headers,
+            timeout=timeout,
+            allow_clearweb=ALLOW_CLEARWEB_FALLBACK,
+            max_redirects=3,
+        )
 
         if response.status_code == 200:
             soup = BeautifulSoup(response.text, "html.parser")
@@ -78,6 +166,7 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
             scraped_text = url_data['title']
     except Exception as e:
         # Return title only on failure, so we don't lose the reference
+        logger.debug("Failed scraping URL '%s': %s", url, e)
         scraped_text = url_data['title']
     
     return url, scraped_text

--- a/scrape.py
+++ b/scrape.py
@@ -53,7 +53,7 @@ def _is_private_or_local_ip(value):
     )
 
 
-def _is_safe_url(url, allow_clearweb=False):
+def _is_safe_url(url, allow_clearweb=False, resolve_hostname=True):
     parsed = urlparse(url)
     hostname = (parsed.hostname or "").lower()
 
@@ -77,6 +77,10 @@ def _is_safe_url(url, allow_clearweb=False):
     if ip_check is False:
         return True
 
+    if not resolve_hostname:
+        # Avoid local DNS lookups when traffic is already routed through Tor.
+        return True
+
     try:
         resolved = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
     except Exception:
@@ -90,8 +94,16 @@ def _is_safe_url(url, allow_clearweb=False):
     return True
 
 
-def _safe_fetch_with_redirect_policy(session, url, headers, timeout, allow_clearweb=False, max_redirects=3):
-    if not _is_safe_url(url, allow_clearweb=allow_clearweb):
+def _safe_fetch_with_redirect_policy(
+    session,
+    url,
+    headers,
+    timeout,
+    allow_clearweb=False,
+    max_redirects=3,
+    resolve_hostname=True,
+):
+    if not _is_safe_url(url, allow_clearweb=allow_clearweb, resolve_hostname=resolve_hostname):
         raise ValueError(f"Blocked URL by security policy: {url}")
 
     current = url
@@ -99,13 +111,14 @@ def _safe_fetch_with_redirect_policy(session, url, headers, timeout, allow_clear
         response = session.get(current, headers=headers, timeout=timeout, allow_redirects=False)
         if response.status_code in {301, 302, 303, 307, 308} and response.headers.get("Location"):
             next_url = urljoin(current, response.headers["Location"])
-            if not _is_safe_url(next_url, allow_clearweb=allow_clearweb):
+            if not _is_safe_url(next_url, allow_clearweb=allow_clearweb, resolve_hostname=resolve_hostname):
                 raise ValueError(f"Blocked redirect by security policy: {next_url}")
             current = next_url
             continue
         return response
 
     raise ValueError("Blocked URL due to excessive redirects")
+
 
 def get_tor_session():
     """
@@ -129,6 +142,25 @@ def get_tor_session():
     }
     return session
 
+
+def get_clearweb_session():
+    """
+    Creates a requests Session with retries and no proxy for explicit clearweb fallback.
+    """
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        read=3,
+        connect=3,
+        backoff_factor=0.3,
+        status_forcelist=[500, 502, 503, 504]
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
 def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, control_password=None):
     """
     Scrapes a single URL using a robust Tor session.
@@ -142,8 +174,15 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
     }
     
     try:
-        session = get_tor_session()
-        timeout = 45 if use_tor else 30
+        if use_tor:
+            session = get_tor_session()
+            timeout = 45
+            resolve_hostname = False
+        else:
+            session = get_clearweb_session()
+            timeout = 30
+            resolve_hostname = True
+
         response = _safe_fetch_with_redirect_policy(
             session,
             url,
@@ -151,6 +190,7 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
             timeout=timeout,
             allow_clearweb=ALLOW_CLEARWEB_FALLBACK,
             max_redirects=3,
+            resolve_hostname=resolve_hostname,
         )
 
         if response.status_code == 200:
@@ -164,6 +204,9 @@ def scrape_single(url_data, rotate=False, rotate_interval=5, control_port=9051, 
             scraped_text = f"{url_data['title']} - {text}"
         else:
             scraped_text = url_data['title']
+    except ValueError as e:
+        logger.warning("Blocked URL by policy during scrape '%s': %s", url, e)
+        scraped_text = url_data['title']
     except Exception as e:
         # Return title only on failure, so we don't lose the reference
         logger.debug("Failed scraping URL '%s': %s", url, e)

--- a/ui.py
+++ b/ui.py
@@ -29,8 +29,10 @@ def _render_pipeline_error(stage: str, err: Exception) -> None:
 
     if any(token in lower_msg for token in ("anthropic", "x-api-key", "invalid api key", "authentication")):
         hints.insert(0, "- Claude/Anthropic models require a valid `ANTHROPIC_API_KEY`.")
-    elif "openrouter" in lower_msg:
-        hints.insert(0, "- OpenRouter models require `OPENROUTER_API_KEY` and a reachable OpenRouter endpoint.")
+    elif "openrouter" in lower_msg or "user not found" in lower_msg or "code: 401" in lower_msg:
+        hints.insert(0, "- OpenRouter 401/User not found usually means the API key is invalid/expired or has leading/trailing characters.")
+        hints.insert(1, "- Set `OPENROUTER_API_KEY` without extra spaces and verify the key is active in your OpenRouter account.")
+        hints.insert(2, "- Keep `OPENROUTER_BASE_URL` as `https://openrouter.ai/api/v1` unless you intentionally use a custom gateway.")
     elif "openai" in lower_msg or "gpt" in lower_msg:
         hints.insert(0, "- OpenAI models require `OPENAI_API_KEY` with access to the chosen model.")
     elif "google" in lower_msg or "gemini" in lower_msg:

--- a/ui.py
+++ b/ui.py
@@ -117,6 +117,7 @@ if not model_options:
         "Set at least one in your `.env` file and restart Robin.\n\n"
         "See **Provider Configuration** below for details."
     )
+    st.stop()
 
 model = st.sidebar.selectbox(
     "Select LLM Model",


### PR DESCRIPTION
## Summary
This PR hardens scraping behavior against unsafe target resolution and redirect abuse while preserving the existing dark web investigation flow.

## Problem
Scrape targets are derived from untrusted search results. Without strict URL and redirect validation, this can cause unsafe outbound requests (localhost/private/link-local/reserved ranges), and potentially expose operator infrastructure.

## What changed

### 1) Scraper URL policy hardening (`scrape.py`)
- Added strict URL validation before request execution.
- Allows `.onion` targets by default.
- Blocks localhost and private/link-local/multicast/reserved/unspecified IP targets.
- Validates each redirect hop before following.
- Enforces redirect cap.

### 2) Session routing behavior (`scrape.py`)
- `.onion` requests use Tor session.
- Non-onion requests (only when explicitly enabled) use a non-proxied clearweb session.
- Added hostname-based `.onion` detection (using parsed hostname).

### 3) DNS leak reduction for Tor path (`scrape.py`)
- Avoids local DNS resolution during safety checks when traffic is routed via Tor.

### 4) Better operator visibility (`scrape.py`)
- Policy blocks are logged at warning level.
- Other scrape failures remain debug-level fallback behavior.

### 5) Config and safety defaults (`config.py`, `README.md`)
- Added `ALLOW_CLEARWEB_FALLBACK` (default disabled).
- Documented the flag in README.
- Minor config style normalization.

### 6) UI guard (`ui.py`)
- Added `st.stop()` when no models are available to prevent invalid UI state.

## Security impact
- Reduces SSRF-style and unsafe outbound request risk from untrusted result URLs.
- Reduces risk of following unsafe redirect chains.
- Keeps default behavior fail-closed for non-onion scraping.

## Backward compatibility
- Core pipeline remains unchanged for normal onion workflows.
- Non-onion scraping now requires explicit opt-in via:
  - `ALLOW_CLEARWEB_FALLBACK=true`

## Validation
- `python3 -m py_compile config.py scrape.py ui.py search.py health.py llm.py llm_utils.py`
- Local import and dependency smoke checks passed in `.venv`.

## Files changed
- `scrape.py`
- `config.py`
- `ui.py`
- `README.md`
